### PR TITLE
Measure time

### DIFF
--- a/demo/measure_time.py
+++ b/demo/measure_time.py
@@ -1,0 +1,108 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import argparse
+import glob
+import multiprocessing as mp
+import os
+import time
+import cv2
+import tqdm
+import json
+
+from detectron2.config import get_cfg
+from detectron2.data.detection_utils import read_image
+from detectron2.utils.logger import setup_logger
+from detectron2.utils.time_measurement import reset , get_result
+
+from predictor import VisualizationDemo
+
+# constants
+WINDOW_NAME = "COCO detections"
+
+
+def setup_cfg(args):
+    # load config from file and command-line arguments
+    cfg = get_cfg()
+    cfg.merge_from_file(args.config_file)
+    cfg.merge_from_list(args.opts)
+    # Set score_threshold for builtin models
+    cfg.MODEL.RETINANET.SCORE_THRESH_TEST = args.confidence_threshold
+    cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = args.confidence_threshold
+    cfg.MODEL.PANOPTIC_FPN.COMBINE.INSTANCES_CONFIDENCE_THRESH = args.confidence_threshold
+    cfg.freeze()
+    return cfg
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="Detectron2 demo for builtin models")
+    parser.add_argument(
+        "--config-file",
+        default="configs/quick_schedules/mask_rcnn_R_50_FPN_inference_acc_test.yaml",
+        metavar="FILE",
+        help="path to config file",
+    )
+    parser.add_argument(
+        "--input",
+        nargs="+",
+        help="A list of space separated input images; "
+        "or a single glob pattern such as 'directory/*.jpg'",
+    )
+    parser.add_argument(
+        "--output",
+        help="A file or directory to save output visualizations. "
+        "If not given, will show output in an OpenCV window.",
+    )
+
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.5,
+        help="Minimum score for instance predictions to be shown",
+    )
+    parser.add_argument(
+        "--opts",
+        help="Modify config options using the command-line 'KEY VALUE' pairs",
+        default=[],
+        nargs=argparse.REMAINDER,
+    )
+    parser.add_argument(
+        "--iter_count",
+        default=10,
+        type=int,
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    mp.set_start_method("spawn", force=True)
+    args = get_parser().parse_args()
+    setup_logger(name="fvcore")
+    logger = setup_logger()
+    logger.info("Arguments: " + str(args))
+
+    cfg = setup_cfg(args)
+
+    demo = VisualizationDemo(cfg)
+
+    measurement_results = []
+    if len(args.input) == 1:
+        args.input = glob.glob(os.path.expanduser(args.input[0]), recursive=True)
+        assert args.input, "The input path(s) was not found"
+    for path in args.input:
+        # use PIL, to be consistent with evaluation
+        img = read_image(path, format="BGR")
+
+        for i in tqdm.tqdm(range(args.iter_count)):
+            predictions = demo.run_on_image(img)
+        
+        # print(path)
+        # print("detected {} instances".format(len(predictions["instances"])))
+        arr = get_result(False)
+        measurement_results.append({
+            'path': os.path.abspath(path),
+            'num_objects': len(predictions['instances']),
+            'time': arr.tolist(),
+        })
+        reset()
+
+    with open('./measure_log.json', 'w') as f:
+        json.dump(measurement_results, f, indent=4)

--- a/demo/predictor.py
+++ b/demo/predictor.py
@@ -61,9 +61,9 @@ class VisualizationDemo(object):
                 )
             if "instances" in predictions:
                 instances = predictions["instances"].to(self.cpu_device)
-                vis_output = visualizer.draw_instance_predictions(predictions=instances)
+                # vis_output = visualizer.draw_instance_predictions(predictions=instances)
 
-        return predictions, vis_output
+        return predictions 
 
     def _frame_from_video(self, video):
         while video.isOpened():

--- a/detectron2/utils/time_measurement.py
+++ b/detectron2/utils/time_measurement.py
@@ -1,0 +1,47 @@
+import time
+import numpy as np
+
+time_arr = np.ndarray(0)
+
+class Timer:
+    def __init__(self):
+        self.is_measuring = False
+        self.start_time = None
+        self.end_time = None
+
+    def start(self):
+        if not self.is_measuring:
+            self.start_time = time.perf_counter()
+            self.is_measuring = True 
+    
+    def stop(self):
+        if self.is_measuring:
+            self.end_time = time.perf_counter()
+            self.is_measuring = False
+    
+    def getTime(self):
+        return self.end_time - self.start_time
+    
+    def save(self):
+        global time_arr
+        time_arr = np.append(time_arr, self.getTime())
+
+def reset():
+    global time_arr
+    time_arr = np.ndarray(0)
+
+def get_result(print_out=True):
+    global time_arr
+    time_mean = time_arr.mean()
+    time_min = time_arr.min()
+    time_max = time_arr.max()
+    if print_out:
+        print("\n")
+        print("min time:\t{}ms".format(time_min * 1000))
+        print("mean time:\t{}ms".format(time_mean * 1000))
+        print("max time:\t{}ms".format(time_max * 1000))
+    
+    return time_arr
+
+
+

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -332,8 +332,10 @@ class Visualizer:
         Returns:
             output (VisImage): image object with visualizations.
         """
-        boxes = predictions.pred_boxes if predictions.has("pred_boxes") else None
-        scores = predictions.scores if predictions.has("scores") else None
+        # boxes = predictions.pred_boxes if predictions.has("pred_boxes") else None
+        boxes = None
+        # scores = predictions.scores if predictions.has("scores") else None
+        scores = None
         classes = predictions.pred_classes if predictions.has("pred_classes") else None
         labels = _create_text_labels(classes, scores, self.metadata.get("thing_classes", None))
         keypoints = predictions.pred_keypoints if predictions.has("pred_keypoints") else None
@@ -610,6 +612,9 @@ class Visualizer:
                     text_pos = (x0, y0)  # if drawing boxes, put text on the box corner.
                     horiz_align = "left"
                 elif masks is not None:
+                    polygons = masks[i].polygons
+                    if polygons is None or len(polygons) == 0:
+                        continue
                     x0, y0, x1, y1 = masks[i].bbox()
 
                     # draw text in the center (defined by median) when box is not drawn
@@ -636,6 +641,7 @@ class Visualizer:
                     * 0.5
                     * self._default_font_size
                 )
+                font_size = self._default_font_size * 0.7
                 self.draw_text(
                     labels[i],
                     text_pos,
@@ -790,7 +796,7 @@ class Visualizer:
             text,
             size=font_size * self.output.scale,
             family="sans-serif",
-            bbox={"facecolor": "black", "alpha": 0.8, "pad": 0.7, "edgecolor": "none"},
+            # bbox={"facecolor": "black", "alpha": 0.8, "pad": 0.7, "edgecolor": "none"},
             verticalalignment="top",
             horizontalalignment=horizontal_alignment,
             color=color,

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -332,10 +332,8 @@ class Visualizer:
         Returns:
             output (VisImage): image object with visualizations.
         """
-        # boxes = predictions.pred_boxes if predictions.has("pred_boxes") else None
-        boxes = None
-        # scores = predictions.scores if predictions.has("scores") else None
-        scores = None
+        boxes = predictions.pred_boxes if predictions.has("pred_boxes") else None
+        scores = predictions.scores if predictions.has("scores") else None
         classes = predictions.pred_classes if predictions.has("pred_classes") else None
         labels = _create_text_labels(classes, scores, self.metadata.get("thing_classes", None))
         keypoints = predictions.pred_keypoints if predictions.has("pred_keypoints") else None
@@ -612,9 +610,6 @@ class Visualizer:
                     text_pos = (x0, y0)  # if drawing boxes, put text on the box corner.
                     horiz_align = "left"
                 elif masks is not None:
-                    polygons = masks[i].polygons
-                    if polygons is None or len(polygons) == 0:
-                        continue
                     x0, y0, x1, y1 = masks[i].bbox()
 
                     # draw text in the center (defined by median) when box is not drawn
@@ -641,7 +636,6 @@ class Visualizer:
                     * 0.5
                     * self._default_font_size
                 )
-                font_size = self._default_font_size * 0.7
                 self.draw_text(
                     labels[i],
                     text_pos,
@@ -796,7 +790,7 @@ class Visualizer:
             text,
             size=font_size * self.output.scale,
             family="sans-serif",
-            # bbox={"facecolor": "black", "alpha": 0.8, "pad": 0.7, "edgecolor": "none"},
+            bbox={"facecolor": "black", "alpha": 0.8, "pad": 0.7, "edgecolor": "none"},
             verticalalignment="top",
             horizontalalignment=horizontal_alignment,
             color=color,


### PR DESCRIPTION
以下のように実行すると、 `measure_log.json` に推論時間の結果が出力される。出力の単位は「秒」。
```
$ CUDA_LAUNCH_BLOCKING=1 poetry run python demo/measure_time.py --config-file configs/COCO-InstanceSegmentation/mask_rcnn_R_101_C4_3x.yaml --input 'data/donkuru_16_1.jpg' --iter_count 5 --opts MODEL.WEIGHTS detectron2://COCO-InstanceSegmentation/mask_rcnn_R_101_C4_3x/138363239/model_final_a2914c.pkl
$ cat measure_log.json
[
    {
        "path": "/home/y-kawabe/program/detectron2/data/donkuru_16_1.jpg",
        "num_objects": 3,
        "time": [
            0.266946571000517,
            0.23301153000011254,
            0.232069954000508,
            0.2345613930001491,
            0.23234871400018164
        ]
    }
]%                                                          
```

* なお、 `--input` には以下のようにwildcard表記も使える
`--input '../data/denso_data_eval/1448x712/**/*.jpg'`

* baseのcommitは以下
https://github.com/facebookresearch/detectron2/tree/6e150b3adb3be1f18efd0bf940206d99c95dbbd8

## その他
Mask R-CNN以外での動作は未検証