### PR TITLE
demo実行時に、特定のラベルのみmask表示を出力。またラベル表記を削除

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -51,6 +51,10 @@ def get_parser():
         help="A file or directory to save output visualizations. "
         "If not given, will show output in an OpenCV window.",
     )
+    parser.add_argument(
+        "--label",
+        help="A label to limit visualization. The other labels are not shown in output."
+    )
 
     parser.add_argument(
         "--confidence-threshold",
@@ -86,7 +90,7 @@ if __name__ == "__main__":
             # use PIL, to be consistent with evaluation
             img = read_image(path, format="BGR")
             start_time = time.time()
-            predictions, visualized_output = demo.run_on_image(img)
+            predictions, visualized_output = demo.run_on_image(img, args.label)
             logger.info(
                 "{}: {} in {:.2f}s".format(
                     path,

--- a/demo/predictor.py
+++ b/demo/predictor.py
@@ -34,7 +34,7 @@ class VisualizationDemo(object):
         else:
             self.predictor = DefaultPredictor(cfg)
 
-    def run_on_image(self, image):
+    def run_on_image(self, image, label = None):
         """
         Args:
             image (np.ndarray): an image of shape (H, W, C) (in BGR order).
@@ -61,7 +61,7 @@ class VisualizationDemo(object):
                 )
             if "instances" in predictions:
                 instances = predictions["instances"].to(self.cpu_device)
-                vis_output = visualizer.draw_instance_predictions(predictions=instances)
+                vis_output = visualizer.draw_instance_predictions(predictions=instances, selected_label = label)
 
         return predictions, vis_output
 

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -320,7 +320,7 @@ class Visualizer:
         )
         self._instance_mode = instance_mode
 
-    def draw_instance_predictions(self, predictions):
+    def draw_instance_predictions(self, predictions, selected_label = None):
         """
         Draw instance-level prediction results on an image.
 
@@ -365,9 +365,10 @@ class Visualizer:
         # for car only        
         new_masks = []
         for i, label in enumerate(labels):
-            if label == 'car':
+            if label == selected_label:
                 new_masks.append(masks[i])
 
+        # these codes are from SOLO: https://github.com/WXinlong/SOLO/blob/0b0dfb343dc976f88352bb1294567c77586b9065/mmdet/apis/inference.py#L261-L265
         np.random.seed(42)
         color_masks = [
             tuple(map(tuple, np.random.randint(0, 256, (1,3), dtype=np.uint8) / 255))[0]

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -362,21 +362,16 @@ class Visualizer:
             )
             alpha = 0.3
 
-        # for car only        
-        new_masks = []
-        for i, label in enumerate(labels):
-            if label == selected_label:
-                new_masks.append(masks[i])
-
-        # these codes are from SOLO: https://github.com/WXinlong/SOLO/blob/0b0dfb343dc976f88352bb1294567c77586b9065/mmdet/apis/inference.py#L261-L265
-        np.random.seed(42)
-        color_masks = [
-            tuple(map(tuple, np.random.randint(0, 256, (1,3), dtype=np.uint8) / 255))[0]
-            for _ in range(len(new_masks))
-        ]
+        # for label only        
+        if selected_label:
+            new_masks = []
+            for i, label in enumerate(labels):
+                if label == selected_label:
+                    new_masks.append(masks[i])
+            masks = new_masks
 
         self.overlay_instances(
-            masks=new_masks,
+            masks=masks,
             boxes=boxes,
             labels=None,
             keypoints=keypoints,

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -332,8 +332,10 @@ class Visualizer:
         Returns:
             output (VisImage): image object with visualizations.
         """
-        boxes = predictions.pred_boxes if predictions.has("pred_boxes") else None
-        scores = predictions.scores if predictions.has("scores") else None
+        # boxes = predictions.pred_boxes if predictions.has("pred_boxes") else None
+        boxes = None
+        # scores = predictions.scores if predictions.has("scores") else None
+        scores = None
         classes = predictions.pred_classes if predictions.has("pred_classes") else None
         labels = _create_text_labels(classes, scores, self.metadata.get("thing_classes", None))
         keypoints = predictions.pred_keypoints if predictions.has("pred_keypoints") else None
@@ -360,10 +362,22 @@ class Visualizer:
             )
             alpha = 0.3
 
+        # for car only        
+        new_masks = []
+        for i, label in enumerate(labels):
+            if label == 'car':
+                new_masks.append(masks[i])
+
+        np.random.seed(42)
+        color_masks = [
+            tuple(map(tuple, np.random.randint(0, 256, (1,3), dtype=np.uint8) / 255))[0]
+            for _ in range(len(new_masks))
+        ]
+
         self.overlay_instances(
-            masks=masks,
+            masks=new_masks,
             boxes=boxes,
-            labels=labels,
+            labels=None,
             keypoints=keypoints,
             assigned_colors=colors,
             alpha=alpha,
@@ -610,6 +624,9 @@ class Visualizer:
                     text_pos = (x0, y0)  # if drawing boxes, put text on the box corner.
                     horiz_align = "left"
                 elif masks is not None:
+                    polygons = masks[i].polygons
+                    if polygons is None or len(polygons) == 0:
+                        continue
                     x0, y0, x1, y1 = masks[i].bbox()
 
                     # draw text in the center (defined by median) when box is not drawn
@@ -636,6 +653,7 @@ class Visualizer:
                     * 0.5
                     * self._default_font_size
                 )
+                font_size = self._default_font_size * 0.7
                 self.draw_text(
                     labels[i],
                     text_pos,
@@ -790,7 +808,7 @@ class Visualizer:
             text,
             size=font_size * self.output.scale,
             family="sans-serif",
-            bbox={"facecolor": "black", "alpha": 0.8, "pad": 0.7, "edgecolor": "none"},
+            # bbox={"facecolor": "black", "alpha": 0.8, "pad": 0.7, "edgecolor": "none"},
             verticalalignment="top",
             horizontalalignment=horizontal_alignment,
             color=color,
@@ -1021,7 +1039,8 @@ class Visualizer:
             segment,
             fill=True,
             facecolor=mplc.to_rgb(color) + (alpha,),
-            edgecolor=edge_color,
+            # edgecolor=edge_color,
+            edgecolor=None,
             linewidth=max(self._default_font_size // 15 * self.output.scale, 1),
         )
         self.output.ax.add_patch(polygon)


### PR DESCRIPTION
以下のように指定すると、 `person` のみマスクを掛けて推論結果を出力してくれる。

```
poetry run python demo/demo.py --config-file configs/COCO-InstanceSegmentation/mask_rcnn_R_101_C4_3x.yaml \
  --input data/donkuru_16_1.jpg \
  --output outputs/donkuru_20201109_person.jpg \
  --label person \
   --opts MODEL.WEIGHTS detectron2://COCO-InstanceSegmentation/mask_rcnn_R_101_C4_3x/138363239/model_final_a2914c.pkl
```